### PR TITLE
add Kafka addresses to failure message

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,7 +61,7 @@ func New() (*Kafka, error) {
 	}
 	admin, err := sarama.NewClusterAdmin(addrs, client.Config())
 	if err != nil {
-		return nil, fmt.Errorf("cannot connect to Kafka cluster: %v", err)
+		return nil, fmt.Errorf("cannot connect to Kafka cluster at %q: %v", addrs, err)
 	}
 	client.admin = admin
 	return client, nil


### PR DESCRIPTION
This helps to be more sure that the environment is set up correctly.