### PR TITLE
fix client connection loop

### DIFF
--- a/client.go
+++ b/client.go
@@ -84,7 +84,7 @@ func New() (*Kafka, error) {
 			client.admin = admin
 			break
 		}
-		if !a.Next() {
+		if !a.More() {
 			return nil, fmt.Errorf("cannot connect to Kafka cluster at %q after %v: %v", addrs, retryLimit, err)
 		}
 	}


### PR DESCRIPTION
We were calling the wrong method on the retry attempt,
which meant the loop could return a client with a nil admin
field and no error.